### PR TITLE
[EC-201] Add IAM role to adgroup-services-cms ad group for CosmosDB

### DIFF
--- a/infra/resources/database.tf
+++ b/infra/resources/database.tf
@@ -90,3 +90,17 @@ module "db_importadesioni_containers" {
   database_name       = azurerm_cosmosdb_sql_database.db_importadesioni.name
   partition_key_path  = each.value.partition_key_path
 }
+
+resource "azurerm_role_assignment" "role_assignment_cosmos_user_access_admin_ad" {
+  scope                = module.cosmosdb_account.id
+  role_definition_name = "User Access Administrator"
+  principal_id         = data.azuread_group.ad_group_services_cms.object_id
+}
+
+#
+# External dependency
+#
+
+data "azuread_group" "ad_group_services_cms" {
+  display_name = "${local.project}-adgroup-services-cms"
+}


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
<!--- Describe your changes in detail -->
Add `User Access Administrator` role to AD group `io-p-adgroup-services-cms` on `io-p-cosmos-importadesioni` resource

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Team needs to manage lock on the cosmos resource

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Chore (nothing changes by a user perspective)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
